### PR TITLE
Release @cuaklabs/nx plugin@0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## 0.1.1 - 2022-09-09
 
 ### Changed
 - Fix package to inform nx of the current executors provided.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/nx-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cuaklabs nx plugin",
   "bugs": {
     "url": "https://github.com/cuaklabs/nx-plugin/issues"


### PR DESCRIPTION
## 0.1.1 - 2022-09-09

### Changed
- Fix package to inform nx of the current executors provided.
