### PR TITLE
chore: update nx as dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+### Changed
+- Updated `nx` to no longer be a direct dependency.
+
+
+
+
 ## 0.1.3 - 2022-09-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jest": "29.2.0",
     "jest-mock": "29.2.0",
     "lint-staged": "13.0.3",
+    "nx": "15.0.0",
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
     "ts-jest": "29.0.3",
@@ -49,8 +50,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@nrwl/devkit": "^14.5.10",
-    "nx": "^14.5.10"
+    "@nrwl/devkit": "15.0.0"
   },
   "executors": "./executors.json",
   "lint-staged": {


### PR DESCRIPTION
### Changed
- Updated `nx` based dependencies to `@15`.
- Updated `nx` to be a dev dependency.